### PR TITLE
README: Update QEMU deprecated implicit boolean options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Welcome to Hotplugger! This app, as the name might tell you, is a combination of
 * Your QEMU machine must expose a QMP socket like this. The `path=` argument is important, we'll use that filename. It can be either relative or absolute, just make sure you can find and have access to it.
 
   ```
-  -chardev socket,id=mon1,server,nowait,path=./qmp-sock
+  -chardev socket,id=mon1,server=on,wait=off,path=./qmp-sock
   -mon chardev=mon1,mode=control,pretty=on
   ```
 
@@ -95,7 +95,7 @@ This is a work in progress, but here's some steps to get you started:
         ...
         <qemu:commandline>
           <qemu:arg value='-chardev'/>
-          <qemu:arg value='socket,id=mon1,server,nowait,path=/tmp/my-vm-sock'/>
+          <qemu:arg value='socket,id=mon1,server=on,wait=off,path=/tmp/my-vm-sock'/>
           <qemu:arg value='-mon'/>
           <qemu:arg value='chardev=mon1,mode=control,pretty=on'/>
         </qemu:commandline>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to Hotplugger! This app, as the name might tell you, is a combination of
 
 * `monitor.py` and `hotplugger.py` require **Python 3**
 
-* Only tested with QEMU 5.0.0. Untested with older or newer versions.
+* Only tested with QEMU 5.0.0 and 6.0.0. Untested with other versions.
 
 * Your QEMU machine must expose a QMP socket like this. The `path=` argument is important, we'll use that filename. It can be either relative or absolute, just make sure you can find and have access to it.
 


### PR DESCRIPTION
The implicit boolean options format (e.g. `nowait`) is deprecated as QEMU 6.0; the explicit format is 5.x-compatible, so it can be used.

Also updated the compatibility note (v6.0.0 has been tested and confirmed to work).